### PR TITLE
Add mutexes for ServerController's maps

### DIFF
--- a/types/safeMap.go
+++ b/types/safeMap.go
@@ -1,0 +1,34 @@
+package types
+
+import "sync"
+
+type SafeMap[Key comparable, Value any] struct {
+	mutex     sync.Mutex
+	unsafeMap map[Key]Value
+}
+
+func NewSafeMap[Key comparable, Value any]() *SafeMap[Key, Value] {
+	return &SafeMap[Key, Value]{unsafeMap: make(map[Key]Value)}
+}
+
+func (self *SafeMap[Key, Value]) Get(key Key) (Value, bool) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	val, found := self.unsafeMap[key]
+	return val, found
+}
+
+func (self *SafeMap[Key, Value]) Set(key Key, val Value) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	self.unsafeMap[key] = val
+}
+
+func (self *SafeMap[Key, Value]) Delete(key Key) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	delete(self.unsafeMap, key)
+}

--- a/types/safeTreeMap.go
+++ b/types/safeTreeMap.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	"sync"
+
+	"github.com/igrmk/treemap/v2"
+	"golang.org/x/exp/constraints"
+)
+
+type SafeTreeMap[Key constraints.Ordered, Value any] struct {
+	Mutex         sync.Mutex
+	UnsafeTreeMap *treemap.TreeMap[Key, Value]
+}
+
+func NewSafeTreeMap[Key constraints.Ordered, Value any]() *SafeTreeMap[Key, Value] {
+	return &SafeTreeMap[Key, Value]{
+		UnsafeTreeMap: treemap.New[Key, Value](),
+	}
+}
+
+func (self *SafeTreeMap[Key, Value]) Get(key Key) (Value, bool) {
+	self.Mutex.Lock()
+	defer self.Mutex.Unlock()
+
+	val, found := self.UnsafeTreeMap.Get(key)
+	return val, found
+}
+
+func (self *SafeTreeMap[Key, Value]) Set(key Key, val Value) {
+	self.Mutex.Lock()
+	defer self.Mutex.Unlock()
+
+	self.UnsafeTreeMap.Set(key, val)
+}
+
+func (self *SafeTreeMap[Key, Value]) Del(key Key) {
+	self.Mutex.Lock()
+	defer self.Mutex.Unlock()
+
+	self.UnsafeTreeMap.Del(key)
+}


### PR DESCRIPTION
This PR addresses #3.

It adds thread-safe wrappers for map and TreeMap. TreeMap wrapper exposes the mutex and the thread-unsafe TreeMap for fine-grained control, like iterating through the TreeMap. There's room for optimizations, like using RWMutex instead of Mutex, but overall the main goal of this PR was to prevent race conditions.

For testing, I was using this python script (it doesn't exit cleanly, sorry about that):
```python
from threading import Thread
import requests
import random

def list_servers():
    while True:
        r = requests.get('http://127.0.0.1:8000/servers')
        print(r)

def register_server(i):
    local_random = random.Random(i)
    
    data = {
        "advanced": False,
        "anti_cheat_on": False,
        "bonus_frequency": 0,
        "country": "US",
        "current_map": "ctf_Ash",
        "game_style": "CTF",
        "info": "test",
        "max_players": 16,
        "name": "soldank-pepehands",
        "num_bots": 0,
        "os": "no",
        "players": [],
        "port": 12345,
        "private": False,
        "realistic": False,
        "respawn": 5,
        "survival": False,
        "version": "1.0",
        "wm": False
    }

    while True:
        data["port"] = local_random.randint(1, 65535)
        r = requests.post('http://127.0.0.1:8000/servers', json=data)
        print(r)

def get_server(i):
    local_random = random.Random(i)
    
    while True:
        port = local_random.randint(1, 65535)
        r = requests.get(f'http://127.0.0.1:8000/servers/127.0.0.1/{port}')
        print(r)

def get_server_players(i):
    local_random = random.Random(i)
    
    while True:
        port = local_random.randint(1, 65535)
        r = requests.get(f'http://127.0.0.1:8000/servers/127.0.0.1/{port}/players')
        print(r)

threads = []
for i in range(4):
    t = Thread(target=register_server, args=(i,))
    threads.append(t)
    t.start()

for i in range(2):
    t = Thread(target=list_servers)
    threads.append(t)
    t.start()

for i in range(1):
    t = Thread(target=get_server, args=(i + 100,))
    threads.append(t)
    t.start()

for i in range(1):
    t = Thread(target=get_server_players, args=(i + 200,))
    threads.append(t)
    t.start()

for t in threads:
    t.join()

```